### PR TITLE
Preserve URL after Auth Redirect

### DIFF
--- a/src/routes/Auth.tsx
+++ b/src/routes/Auth.tsx
@@ -3,9 +3,6 @@ import { Config } from "../config";
 import api from "../util/api";
 import { useEffect, useState } from "react";
 
-const POST_AUTH_URL = "/home/";
-const BAD_AUTH_URL = "/unauthorized/";
-
 const DEV_JWT = import.meta.env.VITE_DEV_JWT;
 
 async function verifyAuth() {
@@ -13,40 +10,37 @@ async function verifyAuth() {
     localStorage.setItem('jwt', DEV_JWT);
   }
 
-  let jwt = localStorage.getItem("jwt");
+  const urlSearchParams = new URLSearchParams(window.location.search);
+  const token = urlSearchParams.get("token");
 
-  // JWT not in local storage
-  if (!jwt) {
-    console.log("not in local storage!");
-    const urlSearchParams = new URLSearchParams(window.location.search);
-    window.history.pushState({}, document.title, "/");
-
-    // Check if JWT is in our query params
-    jwt = urlSearchParams.get("token");
-    if (jwt) {
-      console.log("jwt in search params!");
-      localStorage.setItem("jwt", jwt);
-    }
+  if (token) {
+    localStorage.setItem("jwt", token);
+    window.history.replaceState({}, document.title, "/auth");
   }
 
-  // jwt in local storage or query params
-  if (jwt) {
-    console.log("FOUND JWT!!!");
-    const response = await api.get("/auth/info");
+  const jwt = localStorage.getItem("jwt");
 
-    const roles = response.data.roles;
+  if (!jwt) {
+    console.log("No JWT found, preparing for login");
 
-    if (roles.includes("ADMIN") || roles.includes("STAFF")) {
-      return <Navigate to={POST_AUTH_URL} replace={true}/>;
-    }
-
-    localStorage.removeItem("jwt");
-    return <Navigate to={BAD_AUTH_URL} replace={true} />;
-  } else {
-    console.log("Redirecting to api login...");
-    window.location.href = Config.API_BASE_URL + "/auth/login/admin/";
+    const loginUrl = Config.API_BASE_URL + "/auth/login/admin/";
+    window.location.href = loginUrl;
     return null;
   }
+
+  const response = await api.get("/auth/info");
+  const roles = response.data.roles;
+
+  if (roles.includes("ADMIN") || roles.includes("STAFF")) {
+    const destination = localStorage.getItem("originalDestination") || "/home/";
+    localStorage.removeItem("originalDestination");
+    return <Navigate to={destination} replace={true} />;
+  }
+
+  console.log("Not authorized");
+  localStorage.removeItem("jwt");
+  localStorage.removeItem("originalDestination");
+  return <Navigate to="/unauthorized/" replace={true} />;
 }
 
 export default function Auth() {

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -3,6 +3,17 @@ import api from '../util/api';
 import { useEffect, useState } from 'react';
 
 async function verifyAuth() {
+  const jwt = localStorage.getItem("jwt");
+  
+  const currentPath = window.location.pathname + window.location.search;
+  if (!jwt && !localStorage.getItem("originalDestination")) {
+    if (currentPath !== "/" && currentPath !== "/auth" && currentPath !== "/auth/") {
+      localStorage.setItem("originalDestination", currentPath);
+    } else {
+      localStorage.setItem("originalDestination", "/home/");
+    }
+  }
+
   const response = await api.get("/auth/info");
 
   const roles = response.data.roles;


### PR DESCRIPTION
• Made sure users get sent back to the page they originally tried to visit after logging in
• Stopped ProtectedRoute from overwriting the destination during login redirects
• Cleaned up localStorage properly after login and role checks.